### PR TITLE
Added os scripts so that prettier commands work across all platforms.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3308,6 +3308,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-script-os": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.1.tgz",
+      "integrity": "sha512-tM3mfchUIpo9WOFioO3eO/lTgRbtqcqBmSkkqfkjXmxn7vvhwykOXxOOKIXFP+ZConvLsS5KskM3yX+XBfDD4g==",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,14 @@
     "start:dev": "nodemon",
     "start": "npm run build && node build/index.js",
     "lint": "eslint . --ext .ts",
-    "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "prettier-watch": "onchange 'src/**/*.ts' -- prettier --write {{changed}}"
+    "prettier-format": "run-script-os",
+    "prettier-format:win32": "prettier --config .prettierrc \"./src/**/*.ts\" --write",
+    "prettier-format:darwin:linux": "prettier --config .prettierrc 'src/**/*.ts' --write",
+    "prettier-format:default": "prettier --config .prettierrc 'src/**/*.ts' --write",
+    "prettier-watch": "run-script-os",
+    "prettier-watch:win32": "onchange \"src/**/*.ts\" -- prettier --write {{changed}}", 
+    "prettier-watch:darwin:linux": "onchange 'src/**/*.ts' -- prettier --write {{changed}}", 
+    "prettier-watch:default": "onchange 'src/**/*.ts' -- prettier --write {{changed}}"
   },
   "husky": {
     "hooks": {
@@ -31,6 +37,7 @@
     "onchange": "^6.1.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
+    "run-script-os": "^1.1.1",
     "ts-node": "^8.3.0",
     "typescript": "^4.0.3"
   }


### PR DESCRIPTION
This PR fixes string character escaping problems that happen on Windows when running the prettier commands.

Original PR: https://github.com/stemmlerjs/simple-typescript-starter/pull/13