### PR TITLE
Fix rendering of tsconfig.json files in GitHub's web view

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Fix how tsconfig.json files are displayed in GitHub's web view,
+# by telling it to read said files as JSON With Comments, the
+# JSON extension used by TypeScript.
+tsconfig.*.json linguist-language=JSON-with-Comments
+tsconfig.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
Tell GitHub to render `tsconfig.json` files in the web view as JSON With Comments.

This was something I discovered [while working on a project](https://github.com/freshgum-bubbles/typedi/blob/develop/tsconfig.typedoc.json).

Support is also added for separate `tsconfig.*.json` files, which seem to be rather popular for using different values for different scenarios / environments.
Happy to remove this if it doesn't align with the project goals.